### PR TITLE
fix: accept Node versions with v-prefix and prerelease tags

### DIFF
--- a/src/cli/node-runtime.ts
+++ b/src/cli/node-runtime.ts
@@ -56,7 +56,7 @@ function parseMinimumNodeVersion(range: string): ParsedVersion {
 }
 
 export function parseVersion(version: string): ParsedVersion {
-  const match = /^([0-9]+)\.([0-9]+)\.([0-9]+)$/.exec(version);
+  const match = /^v?([0-9]+)\.([0-9]+)\.([0-9]+)(?:[-+].*)?$/.exec(version);
   if (match === null) {
     throw new Error(`Unsupported Node.js version format: ${version}`);
   }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -938,11 +938,22 @@ describe("runCli exit thresholds", () => {
     });
   });
 
+  it("accepts supported Node.js runtimes with v prefix and prerelease suffix", async () => {
+    await expect(validateNodeRuntimeVersion("v18.18.0-rc.1")).resolves.toEqual({
+      ok: true,
+      message: "Node.js v18.18.0-rc.1 satisfies supported runtime >=18.18."
+    });
+  });
+
   it("rejects unsupported Node.js runtimes for doctor validation", async () => {
     await expect(validateNodeRuntimeVersion("18.17.9")).resolves.toEqual({
       ok: false,
       message: "Node.js 18.17.9 does not satisfy supported runtime >=18.18."
     });
+  });
+
+  it("rejects invalid Node.js runtime version formats for doctor validation", async () => {
+    await expect(validateNodeRuntimeVersion("18.18")).rejects.toThrow("Unsupported Node.js version format: 18.18");
   });
 });
 


### PR DESCRIPTION
## Summary
- relax Node runtime parsing for doctor checks to accept common v-prefixed and prerelease/build version strings
- keep minimum version comparison on numeric major/minor/patch only
- add regression coverage for accepted and rejected formats

## Validation
- npm test -- tests/cli.test.ts
- npm run build