### PR TITLE
fix: reject blank path values in CLI path options

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -66,6 +66,10 @@ interface CliDependencies {
   stderr?: OutputWriter;
 }
 
+function isBlankPath(value: string): boolean {
+  return value.trim().length === 0;
+}
+
 export async function runCli(argv: string[], dependencies: CliDependencies = {}): Promise<number> {
   const stdout = dependencies.stdout ?? process.stdout;
   const stderr = dependencies.stderr ?? process.stderr;
@@ -190,7 +194,7 @@ export function parseArguments(argv: string[]): ParsedCommand | null {
 
     if (argument === "--config") {
       const nextArgument = args[index + 1];
-      if (nextArgument === undefined || nextArgument.startsWith("-")) {
+      if (nextArgument === undefined || nextArgument.startsWith("-") || isBlankPath(nextArgument)) {
         throw new Error("--config expects a file path.");
       }
 
@@ -201,7 +205,7 @@ export function parseArguments(argv: string[]): ParsedCommand | null {
 
     if (argument.startsWith("--config=")) {
       const value = argument.slice("--config=".length);
-      if (value.length === 0) {
+      if (value.length === 0 || isBlankPath(value)) {
         throw new Error("--config expects a file path.");
       }
 
@@ -232,7 +236,7 @@ export function parseArguments(argv: string[]): ParsedCommand | null {
 
     if (argument === "--output-file") {
       const nextArgument = args[index + 1];
-      if (nextArgument === undefined || nextArgument.startsWith("-")) {
+      if (nextArgument === undefined || nextArgument.startsWith("-") || isBlankPath(nextArgument)) {
         throw new Error("--output-file expects a file path.");
       }
 
@@ -243,7 +247,7 @@ export function parseArguments(argv: string[]): ParsedCommand | null {
 
     if (argument.startsWith("--output-file=")) {
       const value = argument.slice("--output-file=".length);
-      if (value.length === 0) {
+      if (value.length === 0 || isBlankPath(value)) {
         throw new Error("--output-file expects a file path.");
       }
 
@@ -348,7 +352,7 @@ function parseDoctorArguments(argv: string[]): DoctorCliArguments | null {
 
     if (argument === "--config") {
       const nextArgument = argv[index + 1];
-      if (nextArgument === undefined || nextArgument.startsWith("-")) {
+      if (nextArgument === undefined || nextArgument.startsWith("-") || isBlankPath(nextArgument)) {
         throw new Error("--config expects a file path.");
       }
 
@@ -359,7 +363,7 @@ function parseDoctorArguments(argv: string[]): DoctorCliArguments | null {
 
     if (argument.startsWith("--config=")) {
       const value = argument.slice("--config=".length);
-      if (value.length === 0) {
+      if (value.length === 0 || isBlankPath(value)) {
         throw new Error("--config expects a file path.");
       }
 
@@ -369,7 +373,7 @@ function parseDoctorArguments(argv: string[]): DoctorCliArguments | null {
 
     if (argument === "--output-file") {
       const nextArgument = argv[index + 1];
-      if (nextArgument === undefined || nextArgument.startsWith("-")) {
+      if (nextArgument === undefined || nextArgument.startsWith("-") || isBlankPath(nextArgument)) {
         throw new Error("doctor --output-file expects a file path.");
       }
 
@@ -380,7 +384,7 @@ function parseDoctorArguments(argv: string[]): DoctorCliArguments | null {
 
     if (argument.startsWith("--output-file=")) {
       const value = argument.slice("--output-file=".length);
-      if (value.length === 0) {
+      if (value.length === 0 || isBlankPath(value)) {
         throw new Error("doctor --output-file expects a file path.");
       }
 
@@ -492,7 +496,7 @@ function parseListRulesArguments(argv: string[]): ListRulesCliArguments | null {
 
     if (argument === "--output-file") {
       const nextArgument = argv[index + 1];
-      if (nextArgument === undefined || nextArgument.startsWith("-")) {
+      if (nextArgument === undefined || nextArgument.startsWith("-") || isBlankPath(nextArgument)) {
         throw new Error("list-rules --output-file expects a file path.");
       }
 
@@ -503,7 +507,7 @@ function parseListRulesArguments(argv: string[]): ListRulesCliArguments | null {
 
     if (argument.startsWith("--output-file=")) {
       const value = argument.slice("--output-file=".length);
-      if (value.length === 0) {
+      if (value.length === 0 || isBlankPath(value)) {
         throw new Error("list-rules --output-file expects a file path.");
       }
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -182,12 +182,20 @@ describe("parseArguments", () => {
       .toThrowError("--config expects a file path.");
     expect(() => parseArguments(["./fixtures/local-risky", "--config", "--format", "json"]))
       .toThrowError("--config expects a file path.");
+    expect(() => parseArguments(["./fixtures/local-risky", "--config", "   "]))
+      .toThrowError("--config expects a file path.");
+    expect(() => parseArguments(["./fixtures/local-risky", "--config=   "]))
+      .toThrowError("--config expects a file path.");
   });
 
   it("rejects missing --output-file values", () => {
     expect(() => parseArguments(["./fixtures/local-risky", "--output-file"]))
       .toThrowError("--output-file expects a file path.");
     expect(() => parseArguments(["./fixtures/local-risky", "--output-file", "--format", "json"]))
+      .toThrowError("--output-file expects a file path.");
+    expect(() => parseArguments(["./fixtures/local-risky", "--output-file", "   "]))
+      .toThrowError("--output-file expects a file path.");
+    expect(() => parseArguments(["./fixtures/local-risky", "--output-file=   "]))
       .toThrowError("--output-file expects a file path.");
   });
 
@@ -216,6 +224,17 @@ describe("parseArguments", () => {
       .toThrowError("doctor --format expects one of: text, json.");
   });
 
+  it("rejects blank doctor path-like option values", () => {
+    expect(() => parseArguments(["doctor", "./fixtures/local-risky", "--config", "   "]))
+      .toThrowError("--config expects a file path.");
+    expect(() => parseArguments(["doctor", "./fixtures/local-risky", "--config=   "]))
+      .toThrowError("--config expects a file path.");
+    expect(() => parseArguments(["doctor", "./fixtures/local-risky", "--output-file", "   "]))
+      .toThrowError("doctor --output-file expects a file path.");
+    expect(() => parseArguments(["doctor", "./fixtures/local-risky", "--output-file=   "]))
+      .toThrowError("doctor --output-file expects a file path.");
+  });
+
   it("rejects extra list-rules arguments", () => {
     expect(() => parseArguments(["list-rules", "extra"]))
       .toThrowError("list-rules does not accept additional arguments.");
@@ -224,6 +243,13 @@ describe("parseArguments", () => {
   it("rejects invalid list-rules format values", () => {
     expect(() => parseArguments(["list-rules", "--format", "markdown"]))
       .toThrowError("list-rules --format expects one of: tsv, json.");
+  });
+
+  it("rejects blank list-rules output-file values", () => {
+    expect(() => parseArguments(["list-rules", "--output-file", "   "]))
+      .toThrowError("list-rules --output-file expects a file path.");
+    expect(() => parseArguments(["list-rules", "--output-file=   "]))
+      .toThrowError("list-rules --output-file expects a file path.");
   });
 
   it("rejects extra version arguments", () => {


### PR DESCRIPTION
## Summary
- reject whitespace-only values for CLI path-like options at parse time
- apply the same guard to scan, doctor, and list-rules argument parsing
- add regression tests for blank --config / --output-file values

## Related
- Related: #56

## Validation
- npm test -- tests/cli.test.ts
- npm run build