### PR TITLE
fix: reject blank target values in CLI target parsing

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -66,6 +66,10 @@ interface CliDependencies {
   stderr?: OutputWriter;
 }
 
+function isBlankPath(value: string): boolean {
+  return value.trim().length === 0;
+}
+
 export async function runCli(argv: string[], dependencies: CliDependencies = {}): Promise<number> {
   const stdout = dependencies.stdout ?? process.stdout;
   const stderr = dependencies.stderr ?? process.stderr;
@@ -264,6 +268,10 @@ export function parseArguments(argv: string[]): ParsedCommand | null {
       throw new Error("TrustMCP accepts exactly one target: a local directory or a public GitHub repository URL.");
     }
 
+    if (isBlankPath(argument)) {
+      throw new Error("Target must not be blank. Provide a local directory or a public GitHub repository URL.");
+    }
+
     target = argument;
   }
 
@@ -420,6 +428,10 @@ function parseDoctorArguments(argv: string[]): DoctorCliArguments | null {
 
     if (target !== undefined) {
       throw new Error("doctor accepts exactly one target: a local directory, GitHub repository URL, or gh:owner/repo.");
+    }
+
+    if (isBlankPath(argument)) {
+      throw new Error("doctor target must not be blank.");
     }
 
     target = argument;

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -211,6 +211,13 @@ describe("parseArguments", () => {
       .toThrowError("doctor accepts exactly one target: a local directory, GitHub repository URL, or gh:owner/repo.");
   });
 
+  it("rejects blank target arguments", () => {
+    expect(() => parseArguments(["   "]))
+      .toThrowError("Target must not be blank. Provide a local directory or a public GitHub repository URL.");
+    expect(() => parseArguments(["doctor", "   "]))
+      .toThrowError("doctor target must not be blank.");
+  });
+
   it("rejects invalid doctor format values", () => {
     expect(() => parseArguments(["doctor", "./fixtures/local-risky", "--format", "markdown"]))
       .toThrowError("doctor --format expects one of: text, json.");


### PR DESCRIPTION
## Summary
- reject whitespace-only target values in top-level scan parsing
- reject whitespace-only target values in doctor target parsing
- add regression tests for both blank target entry points

## Related
- Related: #57

## Validation
- npm test -- tests/cli.test.ts
- npm run build